### PR TITLE
Fixed Mixer recipes.

### DIFF
--- a/src/main/java/modtweaker/mods/embers/handlers/Mixer.java
+++ b/src/main/java/modtweaker/mods/embers/handlers/Mixer.java
@@ -53,7 +53,7 @@ public class Mixer {
 		if (input4 != null){
 			fluids.add(toFluid(input4));
 		}
-		MineTweakerAPI.apply(new Add(new FluidMixingRecipe(fluids.toArray(new FluidStack[]{null,null,null,null}), toFluid(output))));
+		MineTweakerAPI.apply(new Add(new FluidMixingRecipe(fluids.toArray(new FluidStack[fluids.size()]), toFluid(output))));
 	}
 
 	private static class Add extends BaseListAddition<FluidMixingRecipe> {


### PR DESCRIPTION
Not sure what I was thinking here, maybe I just forgot how my own recipe class worked. Should fix crashes related to any modtweaked mixing recipe with less than four fluid inputs.