### PR TITLE
Make Embers Support not import Actually Additions classes

### DIFF
--- a/src/main/java/modtweaker/mods/embers/Embers.java
+++ b/src/main/java/modtweaker/mods/embers/Embers.java
@@ -1,11 +1,6 @@
 package modtweaker.mods.embers;
 
 import minetweaker.MineTweakerAPI;
-import modtweaker.mods.actuallyadditions.handlers.AtomicReconstructor;
-import modtweaker.mods.actuallyadditions.handlers.CoffeeMaker;
-import modtweaker.mods.actuallyadditions.handlers.Compost;
-import modtweaker.mods.actuallyadditions.handlers.Crusher;
-import modtweaker.mods.actuallyadditions.handlers.Empowerer;
 import modtweaker.mods.embers.handlers.Melter;
 import modtweaker.mods.embers.handlers.Mixer;
 import modtweaker.mods.embers.handlers.Stamper;


### PR DESCRIPTION
I'm not sure why these were here.