### PR TITLE
[Feature]: Add Support for the following Botania Features:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@
 /.analytics/*
 /crash-reports/
 /scripts/*
-/test_scripts/*
 
 /bin/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /.analytics/*
 /crash-reports/
 /scripts/*
+/test_scripts/*
 
 /bin/*
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "4.0.6"
+version = "4.0.7"
 group = "com.blamejared.modtweaker"
 archivesBaseName = "modtweaker"
 
@@ -62,6 +62,7 @@ dependencies {
     deobfCompile "CraftTweaker2:ZenScript:4.0.12.+"
     deobfCompile "mezz.jei:jei_1.12.2:4.8.0.+"
     deobfCompile "com.blamejared:MTLib:3.0.+"
+    deobfCompile "vazkii.botania:Botania:r1.10-353"
 
     deobfCompile("cofh:ThermalExpansion:1.12.2-5.+:deobf") {
         exclude group: 'mezz.jei'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "4.0.7"
+version = "4.0.6"
 group = "com.blamejared.modtweaker"
 archivesBaseName = "modtweaker"
 

--- a/src/main/java/com/blamejared/compat/botania/expansions/KnowledgeAddition.java
+++ b/src/main/java/com/blamejared/compat/botania/expansions/KnowledgeAddition.java
@@ -1,0 +1,40 @@
+package com.blamejared.compat.botania.expansions;
+
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.ZenExpansion;
+import stanhebben.zenscript.annotations.ZenMethod;
+import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.api.lexicon.ILexicon;
+import vazkii.botania.api.lexicon.KnowledgeType;
+import vazkii.botania.common.item.ItemLexicon;
+
+@ZenExpansion("crafttweaker.item.IItemstack")
+@ModOnly("botania")
+@ZenRegister
+public class KnowledgeAddition {
+    @ZenMethod
+    public static void addBotaniaKnowledge(IItemStack stack, String knowledge){
+        ILexicon lexicon = (ILexicon) stack;
+        ItemStack mcItemStack = CraftTweakerMC.getItemStack(stack);
+        if (stack == null || stack.isEmpty()){
+            if (stack instanceof ItemLexicon){
+                if (BotaniaAPI.knowledgeTypes.containsKey(knowledge)){
+                KnowledgeType knowledgeType = BotaniaAPI.knowledgeTypes.get(knowledge);
+                    if (!lexicon.isKnowledgeUnlocked(mcItemStack, knowledgeType)){
+                        ((ItemLexicon) stack).unlockKnowledge(mcItemStack, knowledgeType);
+                    }
+                } else {
+                    CraftTweakerAPI.logError("Provided String is not a valid Knowledge Type");
+                }
+            } else {
+                CraftTweakerAPI.logError("Only Works With The Botania Lexicon");
+            }
+        }
+    }
+}

--- a/src/main/java/com/blamejared/compat/botania/expansions/KnowledgeAddition.java
+++ b/src/main/java/com/blamejared/compat/botania/expansions/KnowledgeAddition.java
@@ -19,7 +19,7 @@ import vazkii.botania.common.item.ItemLexicon;
 @ZenRegister
 public class KnowledgeAddition {
     @ZenMethod
-    public static void addBotaniaKnowledge(IItemStack stack, String knowledge){
+    public void addBotaniaKnowledge(IItemStack stack, String knowledge){
         ILexicon lexicon = (ILexicon) stack;
         ItemStack mcItemStack = CraftTweakerMC.getItemStack(stack);
         if (stack == null || stack.isEmpty()){

--- a/src/main/java/com/blamejared/compat/botania/handlers/Knowledge.java
+++ b/src/main/java/com/blamejared/compat/botania/handlers/Knowledge.java
@@ -5,9 +5,7 @@ import crafttweaker.CraftTweakerAPI;
 import crafttweaker.IAction;
 import crafttweaker.annotations.ModOnly;
 import crafttweaker.annotations.ZenRegister;
-import net.minecraft.client.resources.I18n;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.LanguageMap;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import vazkii.botania.api.BotaniaAPI;
@@ -19,16 +17,13 @@ public class Knowledge {
     private static final String typeName = "Botania Knowledge Variable:";
 
     @ZenMethod
-    public static void registerKnowledgeType(String unlocalized, String localized, String color, boolean autoUnlock){
+    public static void registerKnowledgeType(String unlocalized, String color, boolean autoUnlock){
         if (unlocalized == null || unlocalized.isEmpty()) {
             CraftTweakerAPI.logError("Found null String in " + typeName + " name");
         } else if (color == null || color.isEmpty()){
             CraftTweakerAPI.logError("Found null String in " + typeName + " color");
-        } else if (localized == null || localized.isEmpty()){
-            CraftTweakerAPI.logError("Found null String in " + typeName + " localization");
         } else {
             ModTweaker.LATE_ADDITIONS.add(new Add(unlocalized, color, autoUnlock));
-            LanguageMap.instance.languageList.put("botania.knowledge." + unlocalized, localized);
         }
     }
 

--- a/src/main/java/com/blamejared/compat/botania/handlers/Knowledge.java
+++ b/src/main/java/com/blamejared/compat/botania/handlers/Knowledge.java
@@ -1,0 +1,62 @@
+package com.blamejared.compat.botania.handlers;
+
+import com.blamejared.ModTweaker;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.util.text.translation.LanguageMap;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+import vazkii.botania.api.BotaniaAPI;
+
+@ZenClass("mods.botania.Knowledge")
+@ModOnly("botania")
+@ZenRegister
+public class Knowledge {
+    private static final String typeName = "Botania Knowledge Variable:";
+
+    @ZenMethod
+    public static void registerKnowledgeType(String unlocalized, String localized, String color, boolean autoUnlock){
+        if (unlocalized == null || unlocalized.isEmpty()) {
+            CraftTweakerAPI.logError("Found null String in " + typeName + " name");
+        } else if (color == null || color.isEmpty()){
+            CraftTweakerAPI.logError("Found null String in " + typeName + " color");
+        } else if (localized == null || localized.isEmpty()){
+            CraftTweakerAPI.logError("Found null String in " + typeName + " localization");
+        } else {
+            ModTweaker.LATE_ADDITIONS.add(new Add(unlocalized, color, autoUnlock));
+            LanguageMap.instance.languageList.put("botania.knowledge." + unlocalized, localized);
+        }
+    }
+
+    private static class Add implements IAction {
+        String unlocalized;
+        String color;
+        boolean autoUnlock;
+
+        public Add(String name, String color, boolean autoUnlock) {
+            this.unlocalized = name;
+            this.color = color;
+            this.autoUnlock = autoUnlock;
+        }
+
+        @Override
+        public void apply() {
+            BotaniaAPI.registerKnowledgeType(unlocalized, TextFormatting.getValueByName(color.toUpperCase()), autoUnlock);
+        }
+
+        @Override
+        public String describe() {
+            String Output;
+            if (autoUnlock){
+                Output = "Enabled";
+            } else {
+                Output = "Disabled";
+            }
+            return "Adding Knowledge Type: " + unlocalized + " With Auto-Unlock: " + Output;
+        }
+    }
+}

--- a/test_scripts/botania.zs
+++ b/test_scripts/botania.zs
@@ -28,12 +28,16 @@ mods.botania.RuneAltar.removeRecipe(<botania:rune>);
 
 mods.botania.Lexicon.addCategory("mtdev");
 mods.botania.Lexicon.addEntry("deventry", "mtdev", <minecraft:nether_star>);
-mods.botania.Lexicon.setEntryKnowledgeType("deventry", "alfheim");
+mods.botania.Lexicon.setEntryKnowledgeType("deventry", "deventry");
 mods.botania.Lexicon.addTextPage("devpage", "deventry", 0);
 mods.botania.Lexicon.addRunePage("devpage2", "deventry", 1, [<minecraft:apple>], [[<minecraft:nether_star>, <minecraft:beacon>, <minecraft:stone>]], [40]);
 mods.botania.Lexicon.addPetalPage("devpage3", "deventry", 2, [<minecraft:apple>], [[<minecraft:stone>, <minecraft:nether_star>]]);
 
 mods.botania.Lexicon.removeCategory("botania.category.generationFlowers");
 mods.botania.Lexicon.removeEntry("botania.entry.relics");
+
+mods.botania.KnowledgeType.AddKnowledgeType("deventry", "DARK_AQUA", true);
+mods.botania.KnowledgeType.AddKnowledgeType("jared", "GOLD", false);
+recipes.addShapeless(<botania:lexicon>.withTag({"knowledge.jared" : true}), [[<botania:lexicon>, <minecraft:diamond>]]);
 
 //This lexicon stuff is tiring.  So it's unfinished.


### PR DESCRIPTION
- KnowledgeType Registration
  - Example:
```
- mods.botania.Knowledge.registerKnowledgeType(String id, String textFormatting, boolean autoUnlock);
- mods.botania.Knowledge.registerKnowledgeType("jared", "GOLD", false);
- mods.botania.Knowledge.registerKnowledgeType("kindlich", "DARK_AQUA", true);
```

//Currently Broken, @jaredlll08 is looking into it.
- Knowledge Addition:
  - Example:
```
recipes.addShapeless("botaniaKnowledgeAddition", <botania:lexicon>, [<botania:lexicon>, <minecraft:diamond>],
        function(output, inputs, crafting) {
        output.addBotaniaKnowledge("jared");
        output.addBotaniaKnowledge("kindlich");
	} 
);
```