### PR TITLE
Add support for Inspirations cauldron recipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ dependencies {
     deobfCompile "team.chisel:Chisel:MC1.12.2-0.2.0.31"
     deobfCompile "com.wayoftime.bloodmagic:BloodMagic:1.12.2-2.2.7-90"
     deobfCompile "info.amerifrance.guideapi:Guide-API:1.12-2.1.4-57"
+	deobfCompile("knightminer:Inspirations:1.12.2-0.1.2.5") {
+        exclude group: 'mezz.jei'
+    }
 }
 
 processResources {

--- a/src/main/java/com/blamejared/ModTweaker.java
+++ b/src/main/java/com/blamejared/ModTweaker.java
@@ -2,6 +2,7 @@ package com.blamejared;
 
 import com.blamejared.compat.botania.Botania;
 import com.blamejared.compat.chisel.Chisel;
+import com.blamejared.compat.inspirations.Inspirations;
 import com.blamejared.compat.tconstruct.TConstruct;
 import crafttweaker.*;
 import net.minecraftforge.fml.common.*;
@@ -51,6 +52,9 @@ public class ModTweaker {
         }
         if(Loader.isModLoaded("chisel")) {
             Chisel.registerCommands();
+        }
+        if(Loader.isModLoaded("inspirations")) {
+            Inspirations.registerCommands();
         }
     }
 }

--- a/src/main/java/com/blamejared/compat/inspirations/Cauldron.java
+++ b/src/main/java/com/blamejared/compat/inspirations/Cauldron.java
@@ -1,0 +1,708 @@
+package com.blamejared.compat.inspirations;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+
+import com.blamejared.ModTweaker;
+import com.blamejared.mtlib.helpers.InputHelper;
+import com.blamejared.mtlib.helpers.LogHelper;
+import com.blamejared.mtlib.utils.BaseAction;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.item.IngredientAny;
+import crafttweaker.api.liquid.ILiquidStack;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import knightminer.inspirations.library.InspirationsRegistry;
+import knightminer.inspirations.library.event.RegisterEvent.RegisterCauldronRecipe;
+import knightminer.inspirations.library.recipe.cauldron.CauldronBrewingRecipe;
+import knightminer.inspirations.library.recipe.cauldron.CauldronDyeRecipe;
+import knightminer.inspirations.library.recipe.cauldron.CauldronFluidRecipe;
+import knightminer.inspirations.library.recipe.cauldron.CauldronFluidTransformRecipe;
+import knightminer.inspirations.library.recipe.cauldron.CauldronPotionRecipe;
+import knightminer.inspirations.library.recipe.cauldron.FillCauldronRecipe;
+import knightminer.inspirations.library.recipe.cauldron.ICauldronRecipe;
+import knightminer.inspirations.library.recipe.cauldron.ISimpleCauldronRecipe;
+import net.minecraft.init.PotionTypes;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.potion.PotionType;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import slimeknights.mantle.util.RecipeMatch;
+import stanhebben.zenscript.annotations.Optional;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.inspirations.Cauldron")
+@ZenRegister
+@ModOnly("inspirations")
+public class Cauldron {
+	/** List of all recipes added by crafttweaker, so we don't remove our own recipes */
+	private static final Set<ICauldronRecipe> ADDED_RECIPES = new HashSet<>();
+	public static final List<Triple<Object, Object, IIngredient>> REMOVED_BREWING = new LinkedList<>();
+	public static final List<Triple<IIngredient, IIngredient, Object>> REMOVED_POTION = new LinkedList<>();
+	public static final List<Triple<IIngredient, IIngredient, EnumDyeColor>> REMOVED_DYE = new LinkedList<>();
+	public static final List<Triple<IIngredient, IIngredient, Fluid>> REMOVED_FLUID = new LinkedList<>();
+	public static final List<Triple<Fluid, IIngredient, Fluid>> REMOVED_FLUID_TRANSFORM = new LinkedList<>();
+	public static final List<Pair<IIngredient, Fluid>> REMOVED_FILL = new LinkedList<>();
+
+	private static boolean init = false;
+
+	private static void init() {
+		if (!init) {
+			MinecraftForge.EVENT_BUS.register(Cauldron.class);
+			init = true;
+		}
+	}
+
+	/*
+	 * Cauldron brewing recipes
+	 */
+
+	@ZenMethod
+	public static void addBrewingRecipe(String output, String input, IIngredient reagent) {
+		ModTweaker.LATE_ADDITIONS.add(new AddBrewing(output, input, reagent));
+	}
+
+	@ZenMethod
+	public static void removeBrewingRecipe(String output, @Optional String input, @Optional IIngredient reagent) {
+		init();
+		CraftTweakerAPI.apply(new RemoveBrewing(output, input, reagent));
+	}
+
+	private static class AddBrewing extends BaseAction {
+		private String output;
+		private String input;
+		private IIngredient reagent;
+
+		public AddBrewing(String output, String input, IIngredient reagent) {
+			super("Cauldron Brewing");
+			this.output = output;
+			this.input = input;
+			this.reagent = reagent;
+		}
+
+		@Override
+		public void apply() {
+			PotionType input = PotionType.getPotionTypeForName(this.input);
+			if (input == null || input == PotionTypes.EMPTY) {
+				CraftTweakerAPI.logError("Could not find potion type for " + this.input + ". Ignoring Cauldron Brewing recipe for " + this.output);
+				return;
+			}
+			PotionType output = PotionType.getPotionTypeForName(this.output);
+			if (output == null || output == PotionTypes.EMPTY) {
+				CraftTweakerAPI.logError("Could not find potion type for " + this.output + ". Ignoring Cauldron Brewing recipe.");
+				return;
+			}
+			Ingredient reagent = Ingredient.fromStacks(CraftTweakerMC.getItemStacks(this.reagent.getItems()));
+			addRecipe(new CauldronBrewingRecipe(input, reagent, output));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return '"' + output + '"';
+		}
+	}
+
+	private static class RemoveBrewing extends BaseAction {
+
+		private String output;
+		private String input;
+		private IIngredient reagent;
+
+		public RemoveBrewing(String output, String input, IIngredient reagent) {
+			super("Cauldron Brewing");
+			this.output = output;
+			this.input = input;
+			this.reagent = reagent;
+		}
+
+		@Override
+		public void apply() {
+			Object input = null;
+			if (this.input != null) {
+				input = PotionType.getPotionTypeForName(this.input);
+				if (input == null || input == PotionTypes.EMPTY) {
+					CraftTweakerAPI.logError("Could not find potion type for " + this.input + ". Ignoring Cauldron Brewing recipe removal " + this.output);
+					return;
+				}
+
+				// internally, inspirations converts water potion types to the fluid water since its the same state
+				if (input == PotionTypes.WATER) {
+					input = FluidRegistry.WATER;
+				}
+			}
+
+			Object output = null;
+			if (this.output != null) {
+				output = PotionType.getPotionTypeForName(this.output);
+				if (output == null || output == PotionTypes.EMPTY) {
+					CraftTweakerAPI.logError("Could not find potion type for " + this.output + ". Ignoring Cauldron Brewing recipe removal.");
+					return;
+				}
+				if (output == PotionTypes.WATER) {
+					output = FluidRegistry.WATER;
+				}
+			}
+
+			REMOVED_BREWING.add(Triple.of(output, input, reagent));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return '"' + output + '"';
+		}
+	}
+
+	/*
+	 * Potion cauldron recipes
+	 */
+
+	@ZenMethod
+	public static void addPotionRecipe(IItemStack output, IIngredient input, String potion) {
+		addPotionRecipe(output, input, potion, 1, null);
+	}
+	@ZenMethod
+	public static void addPotionRecipe(IItemStack output, IIngredient input, String potion, int levels, @Optional Boolean boiling) {
+		if (levels < 0 || levels > 3) {
+			CraftTweakerAPI.logError("Ignoring Cauldron Fluid recipe for " + output.getDisplayName() + ": Invalid levels of " + levels + " given, must be between 0 and 3.");
+			return;
+		}
+		ModTweaker.LATE_ADDITIONS.add(new AddPotion(InputHelper.toStack(output), input, potion, levels, boiling));
+	}
+
+	@ZenMethod
+	public static void removePotionRecipe(IIngredient output, @Optional IIngredient input, @Optional String potion) {
+		init();
+		CraftTweakerAPI.apply(new RemovePotion(output, input, potion));
+	}
+
+	private static class AddPotion extends BaseAction {
+		private ItemStack output;
+		private IIngredient input;
+		private String potion;
+		private int levels;
+		private Boolean boiling;
+
+		public AddPotion(ItemStack output, IIngredient input, String potion, int levels, Boolean boiling) {
+			super("Cauldron Potion");
+			this.output = output;
+			this.input = input;
+			this.potion = potion;
+			this.levels = levels;
+			this.boiling = boiling;
+		}
+
+		@Override
+		public void apply() {
+			RecipeMatch input = fromIIngredient(this.input);
+			if (input == null) {
+				CraftTweakerAPI.logInfo("Could not find matching items for " + this.input.toString() + ". Ignoring Cauldron Dyeing recipe for " + output.getDisplayName());
+				return;
+			}
+			PotionType potion = PotionType.getPotionTypeForName(this.potion);
+			if (potion == null || potion == PotionTypes.EMPTY) {
+				CraftTweakerAPI.logError("Could not find potion type for " + this.potion + ". Ignoring Cauldron Brewing recipe for " + this.output);
+				return;
+			}
+
+			addRecipe(new CauldronPotionRecipe(input, potion, output, levels, boiling));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	private static class RemovePotion extends BaseAction {
+		private IIngredient output;
+		private IIngredient input;
+		private String potion;
+
+		public RemovePotion(IIngredient output, IIngredient input, String potion) {
+			super("Cauldron Potion");
+			this.output = output;
+			this.input = input;
+			this.potion = potion;
+		}
+
+		@Override
+		public void apply() {
+			Object potion = null;
+			if (this.potion != null) {
+				potion = PotionType.getPotionTypeForName(this.potion);
+				if (potion == null || potion == PotionTypes.EMPTY) {
+					CraftTweakerAPI.logError("Could not find potion type for " + this.potion + ". Ignoring Cauldron Brewing recipe removal.");
+					return;
+				}
+				if (potion == PotionTypes.WATER) {
+					potion = FluidRegistry.WATER;
+				}
+			}
+			REMOVED_POTION.add(Triple.of(output, input, potion));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	/*
+	 * Dyeing cauldron recipes
+	 */
+
+	@ZenMethod
+	public static void addDyeRecipe(IItemStack output, IIngredient input, String stringDye) {
+		EnumDyeColor dye = EnumDyeColor.valueOf(stringDye.toUpperCase());
+		if (dye == null) {
+			CraftTweakerAPI.logError("Ignoring Cauldron Dyeing recipe for " + output.getDisplayName() + ": Could not find matching dye color for " + stringDye);
+			return;
+		}
+		ModTweaker.LATE_ADDITIONS.add(new AddDye(InputHelper.toStack(output), input, dye));
+	}
+
+	@ZenMethod
+	public static void removeDyeRecipe(IIngredient output, @Optional IIngredient input, @Optional String stringDye) {
+		init();
+		EnumDyeColor dye = null;
+		if (stringDye != null) {
+			dye = EnumDyeColor.valueOf(stringDye.toUpperCase());
+			if (dye == null) {
+				CraftTweakerAPI.logError("Ignoring Cauldron Dyeing recipe removalS: Could not find matching dye color for " + stringDye);
+				return;
+			}
+		}
+		CraftTweakerAPI.apply(new RemoveDye(output, input, dye));
+	}
+
+	private static class AddDye extends BaseAction {
+		private ItemStack output;
+		private IIngredient input;
+		private EnumDyeColor dye;
+
+		public AddDye(ItemStack output, IIngredient input, EnumDyeColor dye) {
+			super("Cauldron Dyeing");
+			this.output = output;
+			this.input = input;
+			this.dye = dye;
+		}
+
+		@Override
+		public void apply() {
+			RecipeMatch input = fromIIngredient(this.input);
+			if (input == null) {
+				CraftTweakerAPI.logInfo("Could not find matching items for " + this.input.toString() + ". Ignoring Cauldron Dyeing recipe for " + output.getDisplayName());
+				return;
+			}
+
+			addRecipe(new CauldronDyeRecipe(input, dye, output));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	private static class RemoveDye extends BaseAction {
+		private IIngredient output;
+		private IIngredient input;
+		private EnumDyeColor dye;
+
+		public RemoveDye(IIngredient output, IIngredient input, EnumDyeColor dye) {
+			super("Cauldron Dyeing");
+			this.output = output;
+			this.input = input;
+			this.dye = dye;
+		}
+
+		@Override
+		public void apply() {
+			REMOVED_DYE.add(Triple.of(output, input, dye));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	/*
+	 * Cauldron fluid recipes
+	 */
+
+	@ZenMethod
+	public static void addFluidRecipe(IItemStack output, IIngredient input, ILiquidStack fluid) {
+		addFluidRecipe(output, input, fluid, 1, null);
+	}
+
+	@ZenMethod
+	public static void addFluidRecipe(IItemStack output, IIngredient input, ILiquidStack fluid, int levels, @Optional Boolean boiling) {
+		if (levels < 0 || levels > 3) {
+			CraftTweakerAPI.logError("Ignoring Cauldron Fluid recipe for " + output.getDisplayName() + ": Invalid levels of " + levels + " given, must be between 0 and 3.");
+			return;
+		}
+		ModTweaker.LATE_ADDITIONS .add(new AddFluid(InputHelper.toStack(output), input, InputHelper.toFluid(fluid), levels, boiling));
+	}
+
+	@ZenMethod
+	public static void addFluidTransform(ILiquidStack output, IIngredient input, ILiquidStack fluid) {
+		addFluidTransform(output, input, fluid, 3, null);
+	}
+
+	@ZenMethod
+	public static void addFluidTransform(ILiquidStack output, IIngredient input, ILiquidStack fluid, int maxLevel, @Optional Boolean boiling) {
+		if (maxLevel < 1 || maxLevel > 3) {
+			CraftTweakerAPI.logError("Ignoring Cauldron Fluid recipe for " + output.getDisplayName() + ": Invalid max level of " + maxLevel + " given, must be between 1 and 3.");
+			return;
+		}
+		ModTweaker.LATE_ADDITIONS.add(new AddFluidTransform(InputHelper.toFluid(output), input, InputHelper.toFluid(fluid), maxLevel, boiling));
+	}
+
+	@ZenMethod
+	public static void removeFluidRecipe(IIngredient output, @Optional IIngredient input, @Optional ILiquidStack fluid) {
+		init();
+		CraftTweakerAPI.apply(new RemoveFluid(output, input, fluid));
+	}
+
+	@ZenMethod
+	public static void removeFluidTransform(IIngredient output, @Optional IIngredient input, @Optional ILiquidStack fluid) {
+		init();
+		CraftTweakerAPI.apply(new RemoveFluidTransform(output, input, fluid));
+	}
+
+	private static class AddFluid extends BaseAction {
+		private ItemStack output;
+		private IIngredient input;
+		private FluidStack fluid;
+		private Boolean boiling;
+		private int levels;
+
+		public AddFluid(ItemStack output, IIngredient input, FluidStack fluid, int levels, Boolean boiling) {
+			super("Cauldron Fluid");
+			this.output = output;
+			this.input = input;
+			this.fluid = fluid;
+			this.boiling = boiling;
+			this.levels = levels;
+		}
+
+		@Override
+		public void apply() {
+			RecipeMatch input = fromIIngredient(this.input);
+			if (input == null) {
+				CraftTweakerAPI.logInfo("Could not find matching items for " + this.input.toString() + ". Ignoring Cauldron Fluid recipe for " + output.getDisplayName());
+				return;
+			}
+
+			addRecipe(new CauldronFluidRecipe(input, fluid.getFluid(), output, boiling, levels));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	private static class AddFluidTransform extends BaseAction {
+		private FluidStack output;
+		private IIngredient input;
+		private FluidStack fluid;
+		private Boolean boiling;
+		private int maxLevels;
+
+		public AddFluidTransform(FluidStack output, IIngredient input, FluidStack fluid, int maxLevels, Boolean boiling) {
+			super("Cauldron Fluid");
+			this.output = output;
+			this.input = input;
+			this.fluid = fluid;
+			this.maxLevels = maxLevels;
+			this.boiling = boiling;
+		}
+
+		@Override
+		public void apply() {
+			RecipeMatch input = fromIIngredient(this.input);
+			if (input == null) {
+				CraftTweakerAPI.logInfo("Could not find matching items for " + this.input.toString() + ". Ignoring Cauldron Fluid recipe for " + output.getLocalizedName());
+				return;
+			}
+
+			addRecipe(new CauldronFluidTransformRecipe(input, fluid.getFluid(), output.getFluid(), boiling, maxLevels));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	private static class RemoveFluid extends BaseAction {
+		private IIngredient output;
+		private IIngredient input;
+		private ILiquidStack fluid;
+
+		public RemoveFluid(IIngredient output, IIngredient input, ILiquidStack fluid) {
+			super("Cauldron Fluid");
+			this.output = output;
+			this.input = input;
+			this.fluid = fluid;
+		}
+
+		@Override
+		public void apply() {
+			REMOVED_FLUID.add(Triple.of(output, input, InputHelper.getFluid(fluid)));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	private static class RemoveFluidTransform extends BaseAction {
+		private IIngredient output;
+		private IIngredient input;
+		private ILiquidStack fluid;
+
+		public RemoveFluidTransform(IIngredient output, IIngredient input, ILiquidStack fluid) {
+			super("Cauldron Fluid");
+			this.output = output;
+			this.input = input;
+			this.fluid = fluid;
+		}
+
+		@Override
+		public void apply() {
+			Fluid output;
+			if (this.output instanceof IngredientAny) {
+				output = null;
+			} else if (this.output instanceof ILiquidStack) {
+				output = InputHelper.getFluid((ILiquidStack)this.output);
+			} else {
+				CraftTweakerAPI.logError("Ignoring Cauldron Fluid recipe removal: Output must be fluid or wildcard");
+				return;
+			}
+
+			REMOVED_FLUID_TRANSFORM.add(Triple.of(output, input, InputHelper.getFluid(fluid)));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(output);
+		}
+	}
+
+	/*
+	 * Cauldron filling recipe
+	 */
+
+	@ZenMethod
+	public static void addFillRecipe(IIngredient input, ILiquidStack fluid) {
+		addFillRecipe(input, fluid, 1, null);
+	}
+
+	@ZenMethod
+	public static void addFillRecipe(IIngredient input, ILiquidStack fluid, int amount, @Optional IItemStack container) {
+		if (amount < 1 || amount > 3) {
+			CraftTweakerAPI.logError("Ignoring Cauldron Fluid recipe for " + fluid.getDisplayName() + ": Invalid amount " + amount + " given, must be between 1 and 3.");
+			return;
+		}
+		ModTweaker.LATE_ADDITIONS.add(new AddFill(input, InputHelper.toFluid(fluid), amount, InputHelper.toStack(container)));
+	}
+
+	@ZenMethod
+	public static void removeFillRecipe(IIngredient input, @Optional ILiquidStack fluid) {
+		init();
+		CraftTweakerAPI.apply(new RemoveFill(input, fluid));
+	}
+
+	private static class AddFill extends BaseAction {
+		private IIngredient input;
+		private FluidStack fluid;
+		private int amount;
+		private ItemStack container;
+
+		public AddFill(IIngredient input, FluidStack fluid, int amount, ItemStack container) {
+			super("Cauldron Fill");
+			this.fluid = fluid;
+			this.input = input;
+			this.amount = amount;
+			this.container = container;
+		}
+
+		@Override
+		public void apply() {
+			RecipeMatch input = fromIIngredient(this.input);
+			if (input == null) {
+				CraftTweakerAPI.logInfo("Could not find matching items for " + this.input.toString() + ". Ignoring Cauldron Fill recipe for " + fluid.getLocalizedName());
+				return;
+			}
+
+			addRecipe(new FillCauldronRecipe(input, fluid.getFluid(), amount, container));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(input);
+		}
+	}
+
+	private static class RemoveFill extends BaseAction {
+		private IIngredient input;
+		private ILiquidStack fluid;
+
+		public RemoveFill(IIngredient input, ILiquidStack fluid) {
+			super("Cauldron Fill");
+			this.fluid = fluid;
+			this.input = input;
+		}
+
+		@Override
+		public void apply() {
+			REMOVED_FILL.add(Pair.of(input, InputHelper.getFluid(fluid)));
+		}
+
+		@Override
+		protected String getRecipeInfo() {
+			return LogHelper.getStackDescription(input);
+		}
+	}
+
+	/*
+	 * Removal event
+	 */
+
+	@SubscribeEvent
+	public static void onCauldronRegister(RegisterCauldronRecipe event) {
+		ICauldronRecipe irecipe = event.getRecipe();
+
+		// skip any recipes we added
+		if (ADDED_RECIPES.contains(irecipe)) {
+			return;
+		}
+
+		// if its a type we recognize, try removing it
+		if (irecipe instanceof CauldronBrewingRecipe) {
+			for (Triple<Object, Object, IIngredient> remove : REMOVED_BREWING) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getRight(), null, remove.getMiddle(), remove.getLeft())) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+
+		} else if (irecipe instanceof CauldronDyeRecipe) {
+			for (Triple<IIngredient, IIngredient, EnumDyeColor> remove : REMOVED_DYE) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getMiddle(), remove.getLeft(), remove.getRight(), null)) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+
+			// fluid transform inherits from fluid, so we need to check it first
+		} else if (irecipe instanceof CauldronFluidTransformRecipe) {
+			for (Triple<Fluid, IIngredient, Fluid> remove : REMOVED_FLUID_TRANSFORM) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getMiddle(), null, remove.getRight(), remove.getLeft())) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+
+			// fill cauldron also inherits from fluid recipe
+		} else if (irecipe instanceof FillCauldronRecipe) {
+			for (Pair<IIngredient, Fluid> remove : REMOVED_FILL) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getLeft(), null, null, remove.getRight())) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+
+		} else if (irecipe instanceof CauldronFluidRecipe) {
+			for (Triple<IIngredient, IIngredient, Fluid> remove : REMOVED_FLUID) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getMiddle(), remove.getLeft(), remove.getRight(), null)) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+		} else if (irecipe instanceof CauldronPotionRecipe) {
+			for (Triple<IIngredient, IIngredient, Object> remove : REMOVED_POTION) {
+				if (checkRecipeMatches((ISimpleCauldronRecipe) irecipe, remove.getMiddle(), remove.getLeft(), remove.getRight(), null)) {
+					event.setCanceled(true);
+					return;
+				}
+			}
+		}
+	}
+
+	/*
+	 * Helpers
+	 */
+
+	private static void addRecipe(ICauldronRecipe recipe) {
+		ADDED_RECIPES.add(recipe);
+		InspirationsRegistry.addCauldronRecipe(recipe);
+	}
+
+	private static RecipeMatch fromIIngredient(IIngredient ingredient) {
+		List<ItemStack> ingredients = ingredient.getItems().stream().map(CraftTweakerMC::getItemStack).collect(Collectors.toList());
+		if (ingredients.isEmpty()) {
+			return null;
+		}
+		int amount = ingredient.getAmount();
+		return RecipeMatch.of(ingredients, amount, amount);
+	}
+
+	private static boolean checkRecipeMatches(ISimpleCauldronRecipe recipe, IIngredient input, IIngredient output, Object inputState, Object outputState) {
+		// check input state, output state, and output for matching or being null
+		if ((outputState == null || compareFluids(outputState, recipe.getState()))
+				&& (inputState == null || compareFluids(inputState, recipe.getInputState()))
+				&& (output == null || output.matches(CraftTweakerMC.getIItemStack(recipe.getResult())))) {
+
+			// if the input is null, this recipe matches
+			if (input == null) {
+				return true;
+			}
+
+			// otherwise check if any stack matches the input
+			for (ItemStack stack : recipe.getInput()) {
+				if (input.matches(CraftTweakerMC.getIItemStack(stack))) {
+					return true;
+				}
+			}
+		}
+
+		// recipe did not match
+		return false;
+	}
+
+	/**
+	 * Compares two objects which may or may not be fluids, as Forge fluid delegates are not always consistent and do not override equals()
+	 */
+	private static boolean compareFluids(Object first, Object second) {
+		if(first == second) {
+			return true;
+		}
+
+		if(first instanceof Fluid && second instanceof Fluid) {
+			return ((Fluid)first).getName().equals(((Fluid)second).getName());
+		}
+
+		return false;
+	}
+}

--- a/src/main/java/com/blamejared/compat/inspirations/Inspirations.java
+++ b/src/main/java/com/blamejared/compat/inspirations/Inspirations.java
@@ -1,0 +1,58 @@
+package com.blamejared.compat.inspirations;
+
+import static crafttweaker.mc1120.commands.SpecialMessagesChat.getClickableCommandText;
+import static crafttweaker.mc1120.commands.SpecialMessagesChat.getLinkToCraftTweakerLog;
+import static crafttweaker.mc1120.commands.SpecialMessagesChat.getNormalMessage;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.mc1120.commands.CTChatCommand;
+import crafttweaker.mc1120.commands.CraftTweakerCommand;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.potion.PotionType;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextComponentString;
+
+public class Inspirations {
+
+    public static void registerCommands() {
+        CTChatCommand.registerCommand(new CraftTweakerCommand("inspirations") {
+
+            @Override
+            protected void init() {
+                setDescription(getClickableCommandText("\u00A72/ct inspirations {dyes|potions}", "/ct inspirations {dyes|potions}", false),
+                		getNormalMessage(" \u00A73Dumps all the dye names or potion type resource locations to the log"));
+            }
+
+            @Override
+            public void executeCommand(MinecraftServer server, ICommandSender sender, String[] arguments) {
+                List<String> args = Arrays.asList(arguments);
+                if(args.contains("dyes")) {
+                    CraftTweakerAPI.logCommand("Inspirations Dye Colors:");
+                    for(EnumDyeColor dye : EnumDyeColor.values()) {
+                        CraftTweakerAPI.logCommand(dye.getName());
+                    }
+                } else if(args.contains("potions")) {
+                    CraftTweakerAPI.logCommand("Inspirations Potion Types:");
+                    // ensure the potion names are sorted
+                    for(ResourceLocation potion : new TreeSet<>(PotionType.REGISTRY.getKeys())) {
+                        CraftTweakerAPI.logCommand(potion.toString());
+                    }
+                } else {
+                    if(sender != null) {
+                        sender.sendMessage(new TextComponentString("Invalid arguments for command. Valid arguments: dyes, potions"));
+                    }
+                }
+
+                if(sender != null) {
+                    sender.sendMessage(getLinkToCraftTweakerLog("List generated;", sender));
+                }
+            }
+        });
+    }
+}

--- a/test_scripts/inspirations.zs
+++ b/test_scripts/inspirations.zs
@@ -1,0 +1,27 @@
+// brewing recipes
+mods.inspirations.Cauldron.addBrewingRecipe("minecraft:invisibility", "minecraft:thick", <minecraft:diamond>);
+mods.inspirations.Cauldron.addBrewingRecipe("minecraft:healing", "minecraft:thick", <ore:gemEmerald>);
+mods.inspirations.Cauldron.removeBrewingRecipe("inspirations:haste");
+mods.inspirations.Cauldron.removeBrewingRecipe("minecraft:awkward", "minecraft:water", <minecraft:nether_wart>);
+
+// dye recipes
+mods.inspirations.Cauldron.addDyeRecipe(<minecraft:diamond>, <minecraft:emerald>, "blue");
+mods.inspirations.Cauldron.addDyeRecipe(<minecraft:emerald>, <minecraft:diamond>, "lime");
+mods.inspirations.Cauldron.removeDyeRecipe(<*>, <*>, "blue");
+mods.inspirations.Cauldron.removeDyeRecipe(<inspirations:carpeted_trapdoor_white>);
+
+// fluid recipes
+mods.inspirations.Cauldron.addFluidRecipe(<minecraft:blaze_rod>, <minecraft:blaze_powder> * 2, <liquid:lava>);
+mods.inspirations.Cauldron.addFluidRecipe(<minecraft:water_bucket>, <minecraft:ice>, <liquid:lava>, 1, true);
+mods.inspirations.Cauldron.addFluidTransform(<liquid:lava>, <minecraft:blaze_powder>, <liquid:water>, 2, false);
+mods.inspirations.Cauldron.removeFluidRecipe(<minecraft:beetroot_soup>);
+mods.inspirations.Cauldron.removeFluidTransform(<liquid:beetroot_soup>, <minecraft:beetroot>, <liquid:water>);
+
+// cauldron filling
+mods.inspirations.Cauldron.addFillRecipe(<ore:gemDiamond>, <liquid:water>, 2, <minecraft:emerald>);
+mods.inspirations.Cauldron.addFillRecipe(<minecraft:emerald>, <liquid:lava>);
+mods.inspirations.Cauldron.removeFillRecipe(<minecraft:beetroot_soup>);
+mods.inspirations.Cauldron.removeFillRecipe(<*>, <liquid:mushroom_stew>);
+
+// potions
+mods.inspirations.Cauldron.addPotionRecipe(<minecraft:golden_apple>, <minecraft:apple>, "minecraft:regeneration", 2);


### PR DESCRIPTION
Adds support for Inspirations cauldron recipes. This requires the latest version of Inspirations (0.1.2.5+). It contains the following methods:

**Potions**

* Potion inputs and outputs use a string resource location representing a vanilla `PotionType`. This is different from the vanilla `Potion` which is currently supported, so a command `/ct inspirations potions` was added to list all types.
* `mods.inspirations.Cauldron.addBrewingRecipe(String output, String input, IIngredient reagent)`
    * Adds a new brewing recipe to convert one potion type into another using the reagent.
* `mods.inspirations.Cauldron.removeBrewingRecipe(String output, [String input, [IIngredient reagent]])`
    * Removes a default brewing recipe, such as a one of the vanilla brewing stand recipes supported by the cauldron.
    * Both input and output support null as a "wildcard", allowing checking just the input or reagent or any combination.

* `mods.inspirations.Cauldron.addPotionRecipe(IItemStack output, IIngredient input, String potion, [int levels, [boolean boiling]])`
    * Adds a recipe which transforms an item by consuming a potion
    * Levels denotes the amount of levels consumed, and by extension required, to perform this recipe. It defaults to 1, but supports 0 to allow a transformation without consuming the potion.
    * Boiling supports true to state the cauldron must be above fire, false to say it must not be above fire, and null (the default), to ignore fire.
* `mods.inspirations.Cauldron.removePotionRecipe(IIngredient output, [IIngredient input, [String potion]])`
    * Removes a potion recipe which matches the given ingredients. By default none ship with Inspirations but the class exists so addons might add one.

**Dyes**

* Dye inputs and outputs use a string dye name representing a value from EnumDyeColor, which represents a color of dyed water. A command `/ct inspirations dyes` was added to list all types in case case or other details are wondered.
* `mods.inspirations.Cauldron.addDyeRecipe(IItemStack output, IIngredient input, String dye)`
    * Adds a recipe which transforms an item by consuming a single level of dyed water
* `mods.inspirations.Cauldron.removeDyeRecipe(IIngredient output, [IIngredient input, [String dye]])`
    * Removes a dye recipe which matches the given ingredients, such as one of the recipes for dyeing wool.

**Fluids**

* Fluid inputs use the native Crafttweaker fluid stacks, though due to the way cauldrons try to mimic vanilla fluid behavior fluid sizes are ignored.
* `mods.inspirations.Cauldron.addFluidRecipe(IItemStack output, IIngredient input, ILiquidStack fluid, [int levels, [boolean boiling]])`
    * Adds a recipe which transforms an item by consuming a fluid
    * Levels denotes the amount of levels consumed, and by extension required, to perform this recipe. It defaults to 1, but supports 0 to allow a transformation without consuming the potion.
    * Boiling supports true to state the cauldron must be above fire, false to say it must not be above fire, and null (the default), to ignore fire.
* `mods.inspirations.Cauldron.removeFluidRecipe(IIngredient output, [IIngredient input, [ILiquidStack fluid]])`
    * Removes a fluid recipe which matches the given ingredients, such as one of the recipes to fill a bowl with stew.

* `mods.inspirations.Cauldron.addFluidTransform(ILiquidStack output, IIngredient input, ILiquidStack fluid, [int maxLevels, [boolean boiling]])`
    * Adds a new fluid recipe to convert one fluid into another using the reagent.
    * Max level determines the maximum of fluid allowed in the cauldron for this transformation to happen. Used in Inspirations to make some recipes cost more items for more fluids in the cauldron.
    * Boiling supports true to state the cauldron must be above fire, false to say it must not be above fire, and null (the default), to ignore fire.
* `mods.inspirations.Cauldron.removeFluidTransform(IIngredient output, [IIngredient input, [IFluidStack fluid]])`
    * Removes a default fluid transform recipe, such as from stew recipes.
    * While the output is IIngredient, it will log an error if it is not a fluid or wildcard.

* `mods.inspirations.Cauldron.addFillRecipe(IIngredient input, ILiquidStack fluid, [int levels, [IItemStack container]])`
    * Adds a new recipe to fill the cauldron with a fluid.
    * Levels determines how much the cauldron is filled by.
    * Container is the stack returned after filling the cauldron. Defaults to empty (no return).
* `mods.inspirations.Cauldron.removeFillRecipe(IIngredient input, [ILiquidStack fluid])`
    * Removes a default fill recipe, such as one for filling with soups.