### PR TITLE
refined storage compat for refined storage 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,9 +51,6 @@ repositories {
         url "http://maven.tterrag.com"
     }
     maven {
-        url "https://dl.bintray.com/raoulvdberge/dev/"
-    }
-    maven {
         url = "http://maven.thiakil.com"
     }
     maven {
@@ -92,10 +89,6 @@ dependencies {
         exclude group: 'mezz.jei'
     }
     deobfCompile "team.chisel.ctm:CTM:MC1.12-0.2.3.12"
-
-    deobfCompile("refinedstorage:refinedstorage:1.5.32-1498") {
-        exclude group: 'mezz.jei'
-    }
     deobfCompile("knightminer.tcomplement:TinkersComplement:1.12.1-0.2.1.3") {
         exclude group: 'mezz.jei'
     }

--- a/src/main/java/com/blamejared/compat/refinedstorage/Solderer.java
+++ b/src/main/java/com/blamejared/compat/refinedstorage/Solderer.java
@@ -1,106 +1,32 @@
 package com.blamejared.compat.refinedstorage;
 
-import com.blamejared.ModTweaker;
-import com.blamejared.mtlib.helpers.*;
-import com.blamejared.mtlib.utils.*;
-import com.blamejared.reference.Reference;
-import com.raoulvdberge.refinedstorage.api.solderer.ISoldererRecipe;
-import com.raoulvdberge.refinedstorage.apiimpl.API;
 import crafttweaker.CraftTweakerAPI;
-import crafttweaker.annotations.*;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.*;
-import stanhebben.zenscript.annotations.*;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
 
-import javax.annotation.Nonnull;
-import java.util.*;
+//TODO - remove aas the solderer doesn't exist any more
 
 @ZenClass("mods.refinedstorage.Solderer")
 @ModOnly("refinedstorage")
 @ZenRegister
+@Deprecated
 public class Solderer {
-    
-    
-    @ZenMethod
-    public static void addRecipe(String name, IItemStack output, int time, IItemStack[] rows) {
-        if(rows.length != 3) {
-            CraftTweakerAPI.logError("Invalid array length! There have to have 3 items in the array! Use null where applicable!", new ArrayIndexOutOfBoundsException());
-            return;
-        }
-        NonNullList<ItemStack> list = NonNullList.from(ItemStack.EMPTY, InputHelper.toStacks(rows));
-        ModTweaker.LATE_ADDITIONS.add(new Add(Collections.singletonList(new ISoldererRecipe() {
-            @Override
-            public ResourceLocation getName() {
-                return new ResourceLocation(Reference.MODID, "name");
-            }
-            
-            @Nonnull
-            @Override
-            public NonNullList<ItemStack> getRow(int row) {
-                return NonNullList.withSize(1, list.get(row));
-            }
-            
-            @Nonnull
-            @Override
-            public ItemStack getResult() {
-                return InputHelper.toStack(output);
-            }
-            
-            @Override
-            public int getDuration() {
-                return time;
-            }
-            
-            @Override
-            public boolean isProjectERecipe() {
-                return false;
-            }
-        })));
-    }
-    
-    @ZenMethod
-    public static void removeRecipe(IItemStack output) {
-        ModTweaker.LATE_REMOVALS.add(new Remove(output));
-    }
-    
-    private static class Add extends BaseListAddition<ISoldererRecipe> {
-        
-        
-        protected Add(List<ISoldererRecipe> recipes) {
-            super("Solderer", API.instance().getSoldererRegistry().getRecipes(), recipes);
-        }
-        
-        @Override
-        protected String getRecipeInfo(ISoldererRecipe recipe) {
-            return LogHelper.getStackDescription(recipe.getResult());
-        }
-        
-    }
-    
-    private static class Remove extends BaseListRemoval<ISoldererRecipe> {
-        
-        private IItemStack output;
-        
-        protected Remove(IItemStack output) {
-            super("Solderer", API.instance().getSoldererRegistry().getRecipes(), Collections.emptyList());
-            this.output = output;
-        }
-        
-        @Override
-        public void apply() {
-            for(ISoldererRecipe recipe : API.instance().getSoldererRegistry().getRecipes()) {
-                if(output.matches(InputHelper.toIItemStack(recipe.getResult()))) {
-                    recipes.add(recipe);
-                }
-            }
-            super.apply();
-        }
-        
-        @Override
-        protected String getRecipeInfo(ISoldererRecipe recipe) {
-            return LogHelper.getStackDescription(recipe.getResult());
-        }
-        
-    }
+
+
+	@ZenMethod
+	@Deprecated
+	public static void addRecipe(String name, IItemStack output, int time, IItemStack[] rows) {
+		CraftTweakerAPI.logError("The solderer has been removed from refined storage in 1.6, nothing to do");
+	}
+
+	@ZenMethod
+	@Deprecated
+	public static void removeRecipe(IItemStack output) {
+		CraftTweakerAPI.logError("The solderer has been removed from refined storage in 1.6, nothing to do");
+
+	}
+
 }


### PR DESCRIPTION
The solderer has been removed in refined storage 1.6 [link to curseforge with changelog](https://minecraft.curseforge.com/projects/refined-storage/files/2587374). I haven't removed the methods to prevent scripts breaking completely but there will now be an error.

Not sure this is the best way to handle this but it works.