### PR TITLE
Fix vague InductionSmelter recipe removal issues.

### DIFF
--- a/src/main/java/com/blamejared/compat/thermalexpansion/InductionSmelter.java
+++ b/src/main/java/com/blamejared/compat/thermalexpansion/InductionSmelter.java
@@ -68,9 +68,20 @@ public class InductionSmelter {
         public void apply() {
             if(!SmelterManager.recipeExists(primaryInput, secondaryInput)) {
                 CraftTweakerAPI.logError("No InductionSmelter recipe exists for: " + primaryInput + " and " + secondaryInput);
+            }
+
+            if(SmelterManager.recipeExists(primaryInput, secondaryInput)) {
+                SmelterManager.removeRecipe(primaryInput, secondaryInput);
+            }
+
+            if(SmelterManager.recipeExists(primaryInput, secondaryInput)) {
+                SmelterManager.removeRecipe(secondaryInput, primaryInput);
+            }
+
+            if(SmelterManager.recipeExists(primaryInput, secondaryInput)) {
+                CraftTweakerAPI.logError("InductionSmelter recipes for: " + primaryInput + " and " + secondaryInput + " still exists after reversing fields.");
                 return;
             }
-            SmelterManager.removeRecipe(primaryInput, secondaryInput);
         }
         
         @Override

--- a/src/main/java/com/blamejared/compat/thermalexpansion/InductionSmelter.java
+++ b/src/main/java/com/blamejared/compat/thermalexpansion/InductionSmelter.java
@@ -66,8 +66,9 @@ public class InductionSmelter {
         
         @Override
         public void apply() {
-            if(!SmelterManager.recipeExists(primaryInput, secondaryInput)) {
+            if(!SmelterManager.recipeExists(primaryInput, secondaryInput) && !SmelterManager.recipeExists(secondaryInput, primaryInput)) {
                 CraftTweakerAPI.logError("No InductionSmelter recipe exists for: " + primaryInput + " and " + secondaryInput);
+                return;
             }
 
             if(SmelterManager.recipeExists(primaryInput, secondaryInput)) {
@@ -80,7 +81,6 @@ public class InductionSmelter {
 
             if(SmelterManager.recipeExists(primaryInput, secondaryInput)) {
                 CraftTweakerAPI.logError("InductionSmelter recipes for: " + primaryInput + " and " + secondaryInput + " still exists after reversing fields.");
-                return;
             }
         }
         


### PR DESCRIPTION
According to King Lemming on the COFH Discord, the correct way to handle recipes for the induction smelter that use multiple of a single item is to swap the order of ingredients. 

Not swapping the order will simply result in the recipe not being removed, but no error being raised. I first though to generate an error saying to swap the order of inputs in ZenScript, but then it seemed obvious just to try calling removeRecipe a second time.