### PR TITLE
Fix Thaumonomicon Infusion & Crucible recipes

### DIFF
--- a/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Crucible.java
+++ b/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Crucible.java
@@ -25,7 +25,7 @@ public class Crucible {
     
     @ZenMethod
     public static void registerRecipe(String name, String researchKey, IItemStack output, IIngredient input, CTAspectStack[] aspects) {
-        ModTweaker.LATE_ADDITIONS.add(new Add(new ResourceLocation(Reference.MODID, name), researchKey, InputHelper.toStack(output), InputHelper.toObject(input), ThaumCraft.getAspects(aspects)));
+        ModTweaker.LATE_ADDITIONS.add(new Add(new ResourceLocation("thaumcraft", name), researchKey, InputHelper.toStack(output), InputHelper.toObject(input), ThaumCraft.getAspects(aspects)));
     }
     
     @ZenMethod

--- a/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Infusion.java
+++ b/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Infusion.java
@@ -24,7 +24,7 @@ public class Infusion {
     @ZenMethod
     public static void registerRecipe(String name, String research, IItemStack output, int instability, CTAspectStack[] aspects, IIngredient centralItem, IIngredient[] recipe) {
         InfusionRecipe infRecipe = new InfusionRecipe(research, InputHelper.toStack(output), instability, ThaumCraft.getAspects(aspects), InputHelper.toObject(centralItem), InputHelper.toObjects(recipe));
-        ModTweaker.LATE_ADDITIONS.add(new Add(new ResourceLocation(name), infRecipe));
+        ModTweaker.LATE_ADDITIONS.add(new Add(new ResourceLocation("thaumcraft", name), infRecipe));
     }
     
     @ZenMethod


### PR DESCRIPTION
Recipes registered for Infusion use no group name when creating a ResourceLocation, while the Crucible uses MODID (modtweaker:). This means that Crucible recipes referenced by the Thaumonomicon cannot be
edited or replaced without breaking the recipe appearing in theThaumonomicon.

This COULD cause issues with previously registered Infusion recipes registered as "thaumcraft:<name>" which will need to be updated to just "<name>".  A potential solution to this could be to check for "thuamcraft:" in the name and don't duplicate, That seems a bit over-the-top though.