### PR TITLE
Adding Thaumcraft Research Categories & Entries

### DIFF
--- a/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Research.java
+++ b/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Research.java
@@ -1,0 +1,163 @@
+package com.blamejared.compat.thaumcraft.handlers.handlers;
+
+import com.blamejared.ModTweaker;
+import com.blamejared.mtlib.utils.BaseAction;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.ModOnly;
+import crafttweaker.annotations.ZenRegister;
+import net.minecraft.util.ResourceLocation;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchEntry;
+import thaumcraft.common.lib.research.ResearchManager;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Method;
+
+@ZenClass("mods.thaumcraft.Research")
+@ZenRegister
+@ModOnly("thaumcraft")
+public class Research {
+    private static File globalDir = new File("scripts");
+    private static JsonParser parser = new JsonParser();
+
+    // Unfortunately, reflection is required to inject properly otherwise
+    // we would have to reimplement all of the parsing functions. Ew.
+    private static Method parseJson = null;
+    private static Method categoryAdd = null;
+
+    @ZenMethod
+    public static void addResearch(String filename) {
+        if (filename.isEmpty() || !globalDir.exists()) {
+            CraftTweakerAPI.logError("Invalid location passed to addResearch or the scripts folder doesn't exist");
+            return;
+        }
+
+        File resource = new File(globalDir, filename);
+
+        if (!resource.exists()) {
+            CraftTweakerAPI.logError("File specified for Thaumcraft research does not exist: " + filename);
+            return;
+        }
+
+        ModTweaker.LATE_ADDITIONS.add(new AddEntries(resource));
+    }
+
+    @ZenMethod
+    public static void addCategory(String key, String researchParent, String resourceIcon, String resourceBackground, String resourceBackground2) {
+        if (key.isEmpty()) {
+            CraftTweakerAPI.logError("Invalid Thaumcraft research category: cannot have a blank name.");
+            return;
+        }
+
+        if (researchParent.isEmpty()) {
+            researchParent = null;
+        }
+
+        if (resourceIcon.isEmpty()) {
+            CraftTweakerAPI.logError("Invalid Thaumcraft research category: must provide an icon resource, eg. thaumcraft:textures/research/cat_artifice.png");
+            return;
+        }
+
+        if (resourceBackground == null || resourceBackground.isEmpty()) {
+            resourceBackground = "thaumcraft:textures/gui/gui_research_back_1.jpg";
+        }
+
+        if (resourceBackground2 != null && resourceBackground2.isEmpty()) {
+            resourceBackground2 = null;
+        }
+
+        ModTweaker.LATE_ADDITIONS.add(new AddCategory(key, researchParent, resourceIcon, resourceBackground, resourceBackground2));
+    }
+
+    private static class AddCategory extends BaseAction {
+        private String key;
+        private String researchParent;
+        private ResourceLocation resourceIcon;
+        private ResourceLocation resourceBackground;
+        private ResourceLocation resourceBackground2;
+
+        AddCategory(String key, String researchParent, String resourceIcon, String resourceBackground, @Nullable String resourceBackground2) {
+            super("ResearchCategory");
+
+            this.key = key;
+            this.researchParent = researchParent;
+            this.resourceIcon = new ResourceLocation(resourceIcon);
+            this.resourceBackground = new ResourceLocation(resourceBackground);
+            this.resourceBackground2 = (resourceBackground2 != null) ? new ResourceLocation(resourceBackground2) : null;
+        }
+
+        @Override
+        public void apply() {
+            if (resourceBackground2 == null) {
+                ResearchCategories.registerCategory(key, researchParent, new AspectList(), resourceIcon, resourceBackground);
+            } else {
+                ResearchCategories.registerCategory(key, researchParent, new AspectList(), resourceIcon, resourceBackground, resourceBackground2);
+            }
+        }
+    }
+
+    private static class AddEntries extends BaseAction {
+        private File resource;
+
+        AddEntries(File resource) {
+            super("ResearchEntries");
+            this.resource = resource;
+        }
+
+        @Override
+        public void apply() {
+            try {
+                InputStream input = new FileInputStream(this.resource);
+
+                InputStreamReader reader = new InputStreamReader(input);
+                JsonObject obj = parser.parse(reader).getAsJsonObject();
+
+                JsonArray entries = obj.get("entries").getAsJsonArray();
+
+                for (JsonElement l : entries) {
+                    try {
+                        addResearchToCategory(parseResearchJson(l.getAsJsonObject()));
+                    } catch (Exception e) {
+                        CraftTweakerAPI.logError("Error loading individual research entry for Thaumcraft file " + this.resource.toString());
+                    }
+                }
+            } catch (Exception e) {
+                CraftTweakerAPI.logError("File specified for Thaumcraft research no longer exists or is invalid: " + this.resource.toString());
+            }
+        }
+
+        private ResearchEntry parseResearchJson(JsonObject obj) throws Exception {
+            if (parseJson == null) {
+                parseJson = ResearchManager.class.getDeclaredMethod("parseResearchJson", JsonObject.class);
+                parseJson.setAccessible(true);
+            }
+
+            return (ResearchEntry) parseJson.invoke(null, obj);
+        }
+
+        private void addResearchToCategory(ResearchEntry entry) throws Exception {
+            if (categoryAdd == null) {
+                categoryAdd = ResearchManager.class.getDeclaredMethod("addResearchToCategory", ResearchEntry.class);
+                categoryAdd.setAccessible(true);
+            }
+
+            categoryAdd.invoke(null, entry);
+        }
+
+        @Override
+        public String describe() {
+            return "Adding new research entry for " + resource.toString();
+        }
+    }
+}


### PR DESCRIPTION
Research Categories are defined by a key (which is usually in uppercase,
although this is unenforced as I'm not sure if it needs to be enforced),
a parent research that must be completed (or a blank string which is
converted to null/null), a string reference to a resource location
(specific textures, i.e., "thaumcraft:textures/misc/vortex.png"), and
likewise for both background elements.

Example:

mods.thaumcraft.Research.addCategory("PERIPHERY", "UNLOCKAUROMANCY", "thaumcraft:textures/misc/vortex.png", "thaumcraft:textures/gui/gui_research_back_2.jpg", "thaumcraft:textures/gui/gui_research_back_over.png");

(Example shameless stolen from Periphery, the only Thaumcraft addon I
had to hand and with which to reference).

Research Entries are defined by specifying the name of a JSON file the
accords the relevant file in the `scripts` folder, following the syntax
outlined at: https://github.com/Azanor/thaumcraft-api/blob/master/research/_example.json.txt

Example:

mods.thaumcraft.Research.addResearch("myresearch.json");

It is not a simple matter of merely using the API to load new research,
as the API specifically searches the file structure of the domain of the
resource location for a file matching the path. Attempts to use things
such as Resource Loader failed.

My solution was to partially re-implement the initial loading function,
and then use Reflection (with Methods cached) to access and call the
relevant functions for parsing the JSON into Research Entries, then then
to insert them into the relevant category.

With caching, and presuming that only a few dozen categories and entries
will be created, I don't believe that Reflection will add any
significant overhead to the loading process.

Research Categories and entries are specifically loaded through the
LATE_ADDITIONS in order to ensure that the Thaumcraft files are loaded
first. I didn't actually test to see what would happen if these
categories were inserted first, what impact it may have on the layout of
the Thaumonomicon, etc.

This was done in response to a request by DemoXin in #modtweaker and
because I thought it would be both an interesting challenge and
something that I may use in a modpack in the future. Hopefully the code
is up to snuff!

Please let me know of any issues.

Final note to this already long one: I feel there's currently no need for removing categories or, for that matter, entries, at least at this time.