### PR TITLE
Fix for NullPointerException when using Crucible.removeRecipe(String name)

### DIFF
--- a/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Crucible.java
+++ b/src/main/java/com/blamejared/compat/thaumcraft/handlers/handlers/Crucible.java
@@ -87,7 +87,7 @@ public class Crucible {
                             toRemove.add(entry.getKey());
                         }
                     }
-                    if(!output.isEmpty()) {
+                    if(output != null && !output.isEmpty()) {
                         if(output.matches(InputHelper.toIItemStack(((CrucibleRecipe) entry.getValue()).getRecipeOutput()))) {
                             toRemove.add(entry.getKey());
                         }


### PR DESCRIPTION
Because using removeRecipe(String name) doesn't cause the variable called 'output' to be set (and shouldn't), it is necessary to check whether it is null when applying the change.