### PR TITLE
Update Inspirations support and add a Mantle RecipeMatch helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     deobfCompile "team.chisel:Chisel:MC1.12.2-0.2.0.31"
     deobfCompile "com.wayoftime.bloodmagic:BloodMagic:1.12.2-2.3.3-101"
     deobfCompile "info.amerifrance.guideapi:Guide-API:1.12-2.1.7-62"
-    deobfCompile("knightminer:Inspirations:1.12.2-0.2.3.63") {
+    deobfCompile("knightminer:Inspirations:1.12.2-0.2.4.70") {
         exclude group: 'mezz.jei'
     }
 }

--- a/src/main/java/com/blamejared/compat/mantle/RecipeMatchIIngredient.java
+++ b/src/main/java/com/blamejared/compat/mantle/RecipeMatchIIngredient.java
@@ -1,0 +1,57 @@
+package com.blamejared.compat.mantle;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.minecraft.CraftTweakerMC;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import slimeknights.mantle.util.RecipeMatch;
+
+public class RecipeMatchIIngredient extends RecipeMatch {
+	private IIngredient ingredient;
+	private List<ItemStack> items;
+	public RecipeMatchIIngredient(IIngredient ingredient) {
+		this(ingredient, 1);
+	}
+
+	public RecipeMatchIIngredient(IIngredient ingredient, int amountMatched) {
+		super(amountMatched, ingredient.getAmount());
+		this.ingredient = ingredient;
+	}
+
+	@Override
+	public List<ItemStack> getInputs() {
+		if(items != null) {
+			return items;
+		}
+		return items = Arrays.stream(ingredient.getItemArray()).map(CraftTweakerMC::getItemStack).collect(Collectors.toList());
+	}
+
+	@Override
+	public Optional<Match> matches(NonNullList<ItemStack> stacks) {
+		List<ItemStack> found = Lists.newLinkedList();
+		int stillNeeded = amountNeeded;
+
+		for(ItemStack stack : stacks) {
+			if(ingredient.matches(CraftTweakerMC.getIItemStack(stack))) {
+				// add the amount found to the list
+				ItemStack copy = stack.copy();
+				copy.setCount(Math.min(copy.getCount(), stillNeeded));
+				found.add(copy);
+				stillNeeded -= copy.getCount();
+
+				// we found enough
+				if(stillNeeded <= 0) {
+					return Optional.of(new Match(found, amountMatched));
+				}
+			}
+		}
+		return Optional.empty();
+	}
+}

--- a/test_scripts/inspirations.zs
+++ b/test_scripts/inspirations.zs
@@ -7,12 +7,15 @@ mods.inspirations.Cauldron.removeBrewingRecipe("minecraft:awkward", "minecraft:w
 // dye recipes
 mods.inspirations.Cauldron.addDyeRecipe(<minecraft:diamond>, <minecraft:emerald>, "blue");
 mods.inspirations.Cauldron.addDyeRecipe(<minecraft:emerald>, <minecraft:diamond>, "lime");
+mods.inspirations.Cauldron.addDyeRecipe(<minecraft:nether_star>, <minecraft:diamond>, "red", 2);
 mods.inspirations.Cauldron.removeDyeRecipe(<*>, <*>, "blue");
 mods.inspirations.Cauldron.removeDyeRecipe(<inspirations:carpeted_trapdoor_white>);
 
 // fluid recipes
 mods.inspirations.Cauldron.addFluidRecipe(<minecraft:blaze_rod>, <minecraft:blaze_powder> * 2, <liquid:lava>);
+mods.inspirations.Cauldron.addFluidRecipe(<minecraft:grass>, <ore:treeLeaves> * 4, <liquid:water>);
 mods.inspirations.Cauldron.addFluidRecipe(<minecraft:water_bucket>, <minecraft:ice>, <liquid:lava>, 1, true);
+mods.inspirations.Cauldron.addFluidRecipe(<minecraft:nether_star>, <minecraft:stick>.withTag({RepairCost: 0, display: {Name: "True Stick"}}), <liquid:lava>);
 mods.inspirations.Cauldron.addFluidTransform(<liquid:lava>, <minecraft:blaze_powder>, <liquid:water>, 2, false);
 mods.inspirations.Cauldron.removeFluidRecipe(<minecraft:beetroot_soup>);
 mods.inspirations.Cauldron.removeFluidTransform(<liquid:beetroot_soup>, <minecraft:beetroot>, <liquid:water>);
@@ -20,8 +23,13 @@ mods.inspirations.Cauldron.removeFluidTransform(<liquid:beetroot_soup>, <minecra
 // cauldron filling
 mods.inspirations.Cauldron.addFillRecipe(<ore:gemDiamond>, <liquid:water>, 2, <minecraft:emerald>);
 mods.inspirations.Cauldron.addFillRecipe(<minecraft:emerald>, <liquid:lava>);
+mods.inspirations.Cauldron.addFillRecipe(<minecraft:cobblestone>, <liquid:lava>, 1, null, true);
+mods.inspirations.Cauldron.addFillRecipe(<minecraft:stone>, <liquid:lava>, 1, <minecraft:glass_bottle>, true);
 mods.inspirations.Cauldron.removeFillRecipe(<minecraft:beetroot_soup>);
 mods.inspirations.Cauldron.removeFillRecipe(<*>, <liquid:mushroom_stew>);
 
 // potions
 mods.inspirations.Cauldron.addPotionRecipe(<minecraft:golden_apple>, <minecraft:apple>, "minecraft:regeneration", 2);
+
+// fluid mix
+mods.inspirations.Cauldron.addFluidMix(<minecraft:golden_apple>, <liquid:lava>, <liquid:iron>);


### PR DESCRIPTION
The main thing this pull request does is replace the awkward and slightly hacky method of convering an `IIngredient` into a `RecipeMatch` with a helper class that converts it directly. This makes it a lot more accurate as the recipe type just delegates the matching to CraftTweaker's logic.

A result of the switch is it fixes two bugs with the Inspirations support:
* Fixes oredict with stack size not matching correctly or showing correctly in JEI
* Fixes NBT being ignored in cauldron recipes.

Additionally, since I created the original cauldron support, I added one more recipe type which now has a CraftTweaker method. I opted out of a remove recipe mostly due to laziness, as there really only is one config enabled recipe by default anyways (plus I forgot to add support for checking for fluids in the API)